### PR TITLE
Marked int as unsigned to prevent compiler warning.

### DIFF
--- a/Xray/Xtrace.mm
+++ b/Xray/Xtrace.mm
@@ -937,7 +937,7 @@ switch ( depth%IMPL_COUNT ) { \
 
 + (void)dumpProfile:(int)count dp:(int)decimalPlaces {
     NSArray *profile = [self profile];
-    for ( int i=0 ; i<count && i<[profile count] ; i++ ) {
+    for ( unsigned int i=0 ; i<count && i<[profile count] ; i++ ) {
         Xtrace *trace = [profile objectAtIndex:i];
         if ( !trace->info->color )
             trace->info->color = noColor;


### PR DESCRIPTION
It should be ok to use an unsigned int here cause it's a loop index based on an NSArray. Personally I would use NSUInteger, this will help when compiling for ARM64. But to stay in line with the rest of the XTrace code I opted not to do so.
